### PR TITLE
Added http endpoint "authmod"

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -67,6 +67,9 @@ function setupRouter (config) {
         }).catch(err => next())
     })
   })
+  router.get('/authmod', (req, res) => {
+    res.json({ ok: 1, name: "screepsmod-auth" });
+  })
   require('./register')(config)
 }
 


### PR DESCRIPTION
This http endpoint can be used to check if the mod is used by any private server.  
This can be a standard for other authentification mods for unofficial clients to show specific connexion forms.  