### PR TITLE
Fix variable type for registerCpu if needed

### DIFF
--- a/lib/cronjobs.js
+++ b/lib/cronjobs.js
@@ -5,6 +5,7 @@ module.exports = function (config) {
 function authUpdates (config) {
   const { common: { storage: { db }}, auth: { screepsrc: { auth: { preventSpawning, registerCpu = 100} = {}} = {}}} = config
   let tgt = new Date(Date.now() - 15000)
+  if (typeof registerCpu === 'string') registerCpu = parseInt(registerCpu, 10);
   let $set = {
     cpu: registerCpu,
     blocked: !!preventSpawning,


### PR DESCRIPTION
If registerCpu is set in the config, the previous code would set it in the database as a string preventing the user from running any code. This seems like a good way to block a user :) This change will update the variable to a number if it is not already a number.