### PR TITLE
add return query parameter

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -22,12 +22,12 @@ module.exports = function (config) {
   app.use(cookieParser())
 
   app.get('/', (req, res, next) => {
-    let { token } = req.query
+    let { token, returnUrl } = req.query
     if (token) res.cookie('auth_token', token)
     if (!registered) {
       registered = true
       let proto = req.get('X-Forwarded-Proto') || req.protocol || 'http'
-      let baseUrl = `${proto}://${req.get('host')}`
+      let baseUrl = returnUrl || `${proto}://${req.get('host')}`
       passport.use('github', new GitHubStrategy({
         callbackURL: baseUrl + '/api/auth/github/return',
         clientID: clientId,

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -23,12 +23,12 @@ module.exports = function (config) {
   app.use(cookieParser())
 
   app.get('/', (req, res, next) => {
-    let { token } = req.query
+    let { token, returnUrl } = req.query
     if (token) res.cookie('auth_token', token)
     if (!registered) {
       registered = true
       let proto = req.get('X-Forwarded-Proto') || req.protocol || 'http'
-      let baseUrl = `${proto}://${req.get('host')}`
+      let baseUrl = returnUrl || `${proto}://${req.get('host')}`
       passport.use('gitlab', new GitLabStrategy({
         callbackURL: baseUrl + '/api/auth/gitlab/return',
         baseURL: gitlabURL,

--- a/lib/steam/index.js
+++ b/lib/steam/index.js
@@ -19,12 +19,13 @@ module.exports = function (config) {
   app.use(cookieParser())
 
   app.get('/', (req, res, next) => {
-    let { token } = req.query
+    let { token, returnUrl } = req.query
     if (token) res.cookie('auth_token', token)
     if (!registered) {
       registered = true
       let proto = req.get('X-Forwarded-Proto') || req.protocol || 'http'
-      let baseUrl = `${proto}://${req.get('host')}`
+      let baseUrl = returnUrl || `${proto}://${req.get('host')}`
+      console.log('baseUrl', baseUrl)
       passport.use('steam', new SteamStrategy({
         returnURL: baseUrl + '/api/auth/steam/return',
         realm: baseUrl,

--- a/lib/steam/index.js
+++ b/lib/steam/index.js
@@ -25,7 +25,6 @@ module.exports = function (config) {
       registered = true
       let proto = req.get('X-Forwarded-Proto') || req.protocol || 'http'
       let baseUrl = returnUrl || `${proto}://${req.get('host')}`
-      console.log('baseUrl', baseUrl)
       passport.use('steam', new SteamStrategy({
         returnURL: baseUrl + '/api/auth/steam/return',
         realm: baseUrl,


### PR DESCRIPTION
This allows us to use screeps-steamless-client in a docker container, by allowing a split between internal and external host.
This also seems to be a 'standard'. Definitely open to change the parameter name.
Considered asking for the full url, but this is currently limited to just the base url.