### PR TITLE
Update /return endpoint to use .writeHead

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -46,7 +46,7 @@ module.exports = function (config) {
       .then(user => authlib.genToken(user._id))
       .then(token => {
         let json = JSON.stringify({ username: req.user.username, token })
-        res.end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body>`)
+        res.writeHead(200, { 'Content-Type':'text/html' }).end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body></html>`)
       })
       .catch(err => res.end('Failed to auth'))
   })

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -48,7 +48,7 @@ module.exports = function (config) {
       .then(user => authlib.genToken(user._id))
       .then(token => {
         let json = JSON.stringify({ username: req.user.username, token })
-        res.end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body>`)
+        res.writeHead(200, { 'Content-Type':'text/html' }).end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body></html>`)
       })
       .catch(err => res.end('Failed to auth'))
   })

--- a/lib/steam/index.js
+++ b/lib/steam/index.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
     authlib.genToken(req.user._id)
       .then(token => {
         let json = JSON.stringify({ username: req.user.username, token, steamid: req.user.steam.id })
-        res.end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body>`)
+        res.writeHead(200, { 'Content-Type':'text/html' }).end(`<html><body><script type="text/javascript">opener.postMessage(JSON.stringify(${json}), '*');window.close();</script></body></html>`)
       })
   })
     // })


### PR DESCRIPTION
I'm not sure if a NodeJS update changed the behavior of res.end or if my reverse proxy setup didn't like the lack of a Content-Type header, but the HTML from this endpoint was displaying as raw text instead of being rendered as HTML to execute the script. Adding in an explicit Content-Type header fixed the problem for me.