### PR TITLE
Provide a better error message when GH/GL authentication is not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 # API
 
 ### config.auth.authUser(username,password)
-Returns a Promise, resovles to either the user object or `false`
+Returns a Promise, resolves to either the user object or `false`
 
 # Github Auth
 To enable github auth, you need to add a github client id and client secret to your .screepsrc  

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -7,14 +7,29 @@ const GitHubStrategy = require('passport-github').Strategy
 const authlib = require('@screeps/backend/lib/authlib')
 const auth = require('@screeps/backend/lib/game/api/auth')
 
-const app = new express.Router()
-
 module.exports = function (config) {
   const clientId = process.env.GITHUB_CLIENT_ID || (config.auth.screepsrc.github && config.auth.screepsrc.github.clientId) || null
   const clientSecret = process.env.GITHUB_CLIENT_SECRET || (config.auth.screepsrc.github && config.auth.screepsrc.github.clientSecret) || null
   const enabled = !!(clientId && clientSecret)
 
   config.auth.info.github = enabled
+
+  config.auth.router.post('/api/user/unlink-github', auth.tokenAuth, (req, res) => {
+    if (!req.user) return
+    config.common.storage.db.users.update({ _id: req.user._id }, { $unset: { github: true } })
+    res.json({ ok: 1 })
+  })
+
+  if (!enabled) {
+    const disabled = express.Router()
+    disabled.use((req, res) => {
+      res.status(503).type('txt').send('GitHub OAuth is not configured.')
+    })
+    config.auth.router.use('/api/auth/github', disabled)
+    return
+  }
+
+  const app = new express.Router()
   let registered = false
 
   app.use(cookieParser())
@@ -53,11 +68,6 @@ module.exports = function (config) {
   })
   // })
   config.auth.router.use('/api/auth/github', app)
-  config.auth.router.post('/api/user/unlink-github', auth.tokenAuth, (req, res) => {
-    if (!req.user) return
-    config.common.storage.db.users.update({ _id: req.user._id }, { $unset: { github: true } })
-    res.json({ ok: 1 })
-  })
 
   function githubFindOrCreateUser (user, id) {
     const { db, env } = config.common.storage

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -7,8 +7,6 @@ const GitLabStrategy = require('passport-gitlab2').Strategy
 const authlib = require('@screeps/backend/lib/authlib')
 const auth = require('@screeps/backend/lib/game/api/auth')
 
-const app = new express.Router()
-
 module.exports = function (config) {
   const clientId = process.env.GITLAB_APP_ID || (config.auth.screepsrc.gitlab && config.auth.screepsrc.gitlab.appId) || null
   const clientSecret = process.env.GITLAB_APP_SECRET || (config.auth.screepsrc.gitlab && config.auth.screepsrc.gitlab.appSecret) || null
@@ -16,6 +14,23 @@ module.exports = function (config) {
   const gitlabURL = process.env.GITLAB_URL || 'https://gitlab.com'
 
   config.auth.info.gitlab = enabled
+
+  config.auth.router.post('/api/user/unlink-gitlab', auth.tokenAuth, (req, res) => {
+    if (!req.user) return
+    config.common.storage.db.users.update({ _id: req.user._id }, { $unset: { gitlab: true } })
+    res.json({ ok: 1 })
+  })
+
+  if (!enabled) {
+    const disabled = express.Router()
+    disabled.use((req, res) => {
+      res.status(503).type('txt').send('GitLab OAuth is not configured.')
+    })
+    config.auth.router.use('/api/auth/gitlab', disabled)
+    return
+  }
+
+  const app = new express.Router()
   let registered = false
 
   app.use(cookieParser())
@@ -55,11 +70,6 @@ module.exports = function (config) {
   })
   // })
   config.auth.router.use('/api/auth/gitlab', app)
-  config.auth.router.post('/api/user/unlink-gitlab', auth.tokenAuth, (req, res) => {
-    if (!req.user) return
-    config.common.storage.db.users.update({ _id: req.user._id }, { $unset: { gitlab: true } })
-    res.json({ ok: 1 })
-  })
 
   function gitlabFindOrCreateUser (user, id) {
     const { db, env } = config.common.storage


### PR DESCRIPTION
Just something that was bothering me; that we show the user a 500 error instead of something pointing them in the proper direction at least.