### PR TITLE
Regenerate the user token on each API call

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -46,8 +46,13 @@ function setupRouter (config) {
     const token = req.get('x-token')
     if (token) {
       authlib.checkToken(token, true)
-        .then(() => {
+        .then((user) => {
           req.headers['x-server-password'] = process.env.SERVER_PASSWORD || ''
+          return authlib.genToken(user._id)
+        })
+        .then((freshToken) => {
+          res.set('X-Token', freshToken)
+          res.set('X-Username', freshToken)
           next()
         })
         .catch(() => next())


### PR DESCRIPTION
This fixes the issue where the client loses access way faster than on the official server.