### PR TITLE
Rework the configuration system to handle both .screepsrc and config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,33 +25,60 @@
 2. Run `setPassword('Username', 'YourDesiredPassword')`
 3. Now you should be able to login via API
 
-# API
+# Configuration
 
-### config.auth.authUser(username,password)
-Returns a Promise, resolves to either the user object or `false`
+Registration settings can be provided either via `.screepsrc` or, with [screepsmod-admin-utils](https://github.com/ScreepsMods/screepsmod-admin-utils) installed, `config.yml` (`serverConfig`).
 
-# Github Auth
-To enable github auth, you need to add a github client id and client secret to your .screepsrc  
-(Or ENV vars GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET with other launchers)
+When the same setting exists in both, **`config.yml` takes precedence**, and those settings are live-reloaded without restarting the server.
+
+## Server Password
+
+Set `SERVER_PASSWORD` in the environment to protect the server and disable user registration.
+
+When set:
+
+- New user registration via `/api/register/submit` is rejected
+- `config.auth.info.allowRegistration` is `false`
+- Authenticated API requests include the password as the `X-Server-Password` header
+
+Clients connecting to the server must send this password (for example via the `X-Server-Password` header) in addition to their auth token.
+
+## Github Auth
+
+Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in the environment.
 
 Make sure to set the callback url to point to `/api/auth/github/return` on your server. ex: `https://screeps.mydomain.com/api/auth/github/return`  
-Get the id and secret from youe Github settings: https://github.com/settings/developers
+Get the id and secret from your Github settings: https://github.com/settings/developers
 
-.screepsrc
-```ini
-[github]
-clientId = <clientId>
-clientSecret = <clientSecret>
-```
+## GitLab Auth
 
-# Initial CPU and Spawn Blocking
+Set `GITLAB_APP_ID`, `GITLAB_APP_SECRET`, and optionally `GITLAB_URL` (defaults to `https://gitlab.com`) in the environment.
+
+## Initial CPU and Spawn Blocking
 
 You can set the initial CPU that gets placed on a user (Steam users always receive 100), and also
 control whether the new user can place spawns. This can be used in combination with a whitelist
 or manual approval to control spawning.
 
+`.screepsrc`
 ```ini
 [auth]
-cpu = 100
+registerCpu = 100
 preventSpawning = false
 ```
+
+`config.yml`
+```yaml
+serverConfig:
+  auth:
+    registerCpu: 100
+    preventSpawning: false
+```
+
+# API
+
+### config.auth.config
+Resolved mod configuration (merged from `.screepsrc` and `config.yml`). Example: `config.auth.config.registerCpu`.
+
+### config.auth.authUser(username,password)
+Returns a Promise, resolves to either the user object or `false`

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,99 @@
+const fs = require('fs')
+const ini = require('ini')
+
+const DEFAULT_AUTH = {
+  registerCpu: 100,
+  preventSpawning: false
+}
+
+function truthy (v) {
+  if (v === true || v === 1) return true
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase()
+    return s === 'true' || s === '1' || s === 'yes' || s === 'on'
+  }
+  return false
+}
+
+function normalizeCpu (value) {
+  const cpu = typeof value !== 'number' ? parseInt(value, 10) : Math.round(value)
+  return Number.isFinite(cpu) ? cpu : DEFAULT_AUTH.registerCpu
+}
+
+function parseScreepsrc () {
+  let auth
+  try {
+    auth = ini.parse(fs.readFileSync('./.screepsrc', { encoding: 'utf8' })).auth || {}
+  } catch (e) {
+    return {}
+  }
+
+  const result = {}
+  if (auth.registerCpu != null) result.registerCpu = normalizeCpu(auth.registerCpu)
+  if (auth.preventSpawning != null) result.preventSpawning = truthy(auth.preventSpawning)
+  return result
+}
+
+function parseConfigYml (source) {
+  let auth
+  if (source == null) {
+    let YAML
+    try {
+      YAML = require('yamljs')
+    } catch (e) {
+      return {}
+    }
+    auth = null
+    for (const file of ['config.yml', 'config.yaml']) {
+      try {
+        fs.statSync(file)
+        auth = YAML.parse(fs.readFileSync(file, 'utf8')).serverConfig?.auth
+        break
+      } catch (e) { }
+    }
+  } else if (source.auth) {
+    auth = source.auth
+  } else {
+    auth = source
+  }
+
+  if (!auth || typeof auth !== 'object') return {}
+
+  const result = {}
+  if (auth.registerCpu != null) result.registerCpu = normalizeCpu(auth.registerCpu)
+  if (auth.preventSpawning != null) result.preventSpawning = truthy(auth.preventSpawning)
+  return result
+}
+
+function mergeAuthConfig (fromScreepsrc, fromYaml) {
+  const screepsrc = fromScreepsrc || {}
+  const yaml = fromYaml || {}
+  return {
+    registerCpu: yaml.registerCpu ?? screepsrc.registerCpu ?? DEFAULT_AUTH.registerCpu,
+    preventSpawning: yaml.preventSpawning ?? screepsrc.preventSpawning ?? DEFAULT_AUTH.preventSpawning
+  }
+}
+
+module.exports = function (config) {
+  const screepsrcAuth = parseScreepsrc()
+  let yamlAuth = {}
+
+  function reloadConfig (source) {
+    yamlAuth = parseConfigYml(source)
+    config.auth.config = mergeAuthConfig(screepsrcAuth, yamlAuth)
+  }
+
+  reloadConfig()
+
+  let utilsBound = false
+  function bindUtils () {
+    if (!config.utils || utilsBound) return
+    utilsBound = true
+    config.utils.on('config:update:auth', reloadConfig)
+  }
+
+  bindUtils()
+  if (config.backend) {
+    config.backend.once('expressPreConfig', bindUtils)
+  }
+}

--- a/lib/cronjobs.js
+++ b/lib/cronjobs.js
@@ -3,12 +3,11 @@ module.exports = function (config) {
 }
 
 function authUpdates (config) {
-  const { common: { storage: { db } }, auth: { screepsrc: { auth: { preventSpawning, registerCpu = 100 } = {} } = {} } } = config
+  const { common: { storage: { db } } } = config
+  const { preventSpawning, registerCpu } = config.auth.config
   const tgt = new Date(Date.now() - 15000)
-  let newCpu = registerCpu
-  if (typeof newCpu === 'string') newCpu = parseInt(newCpu, 10)
   const $set = {
-    cpu: newCpu,
+    cpu: registerCpu,
     blocked: !!preventSpawning,
     authTouched: true
   }

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -8,8 +8,8 @@ const authlib = require('@screeps/backend/lib/authlib')
 const auth = require('@screeps/backend/lib/game/api/auth')
 
 module.exports = function (config) {
-  const clientId = process.env.GITHUB_CLIENT_ID || (config.auth.screepsrc.github && config.auth.screepsrc.github.clientId) || null
-  const clientSecret = process.env.GITHUB_CLIENT_SECRET || (config.auth.screepsrc.github && config.auth.screepsrc.github.clientSecret) || null
+  const clientId = process.env.GITHUB_CLIENT_ID || null
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET || null
   const enabled = !!(clientId && clientSecret)
 
   config.auth.info.github = enabled

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -8,8 +8,8 @@ const authlib = require('@screeps/backend/lib/authlib')
 const auth = require('@screeps/backend/lib/game/api/auth')
 
 module.exports = function (config) {
-  const clientId = process.env.GITLAB_APP_ID || (config.auth.screepsrc.gitlab && config.auth.screepsrc.gitlab.appId) || null
-  const clientSecret = process.env.GITLAB_APP_SECRET || (config.auth.screepsrc.gitlab && config.auth.screepsrc.gitlab.appSecret) || null
+  const clientId = process.env.GITLAB_APP_ID || null
+  const clientSecret = process.env.GITLAB_APP_SECRET || null
   const enabled = !!(clientId && clientSecret)
   const gitlabURL = process.env.GITLAB_URL || 'https://gitlab.com'
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,8 @@
 const Auth = require('./auth')
-const ini = require('ini')
-const fs = require('fs')
 
 module.exports = function (config) {
-  let screepsrc = {}
-  try {
-    screepsrc = ini.parse(fs.readFileSync('./.screepsrc', { encoding: 'utf8' }))
-  } catch (e) { }
-  screepsrc.auth = screepsrc.auth || {}
   const auth = new Auth()
   config.auth = {
-    screepsrc,
     checkPassword (salt, pass, proposed) {
       return auth.verify_password(salt, pass, proposed)
     },
@@ -60,5 +52,6 @@ module.exports = function (config) {
       return Promise.resolve([{ name: 'admin' }])
     }
   }
+  require('./config')(config)
   if (config.backend) require('./backend')(config, auth)
 }

--- a/lib/register.js
+++ b/lib/register.js
@@ -16,13 +16,13 @@ module.exports = function (config) {
     })
   })
   app.post('/submit', bodyParser.json(), (req, res) => {
-    const preventSpawning = config.auth.screepsrc.auth.preventSpawning
+    const { preventSpawning, registerCpu } = config.auth.config
     const body = req.body
     let user = {
       username: body.username,
       usernameLower: body.username.toLowerCase(),
       email: body.email,
-      cpu: config.auth.screepsrc.auth.registerCpu || 100,
+      cpu: registerCpu,
       cpuAvailable: 0,
       registeredDate: new Date(),
       blocked: !!preventSpawning,


### PR DESCRIPTION
This allows using either .screepsrc or config.yml (if admin-utils is available) as a configuration source.

Note that I did remove the `[github]` and `[gitlab]` sections entirely, since I feel like those are supposed to be secret, and passing them through the environment is safer (less risk of having them written out in a source-tracked file like config.yml).