### PR TITLE
Implement auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ serverConfig:
     preventSpawning: false
 ```
 
+# Server CLI commands
+
+This mod uses the `auth` namespace to expose commands to the server's CLI:
+- `auth.setPassword(username, password)` - Set a user's password for API login
+- `auth.createAuthToken(username, description?)` - Creates a full-access API token for a given user
+- `auth.listUserTokenRateLimits(username)` - Lists all tokens for a user and active no-ratelimit windows.
+- `auth.getTokenRateLimit(username?)` - Shows currently active rate-limit usage per token (optionally scoped to one user).
+
 # Auth token rate limiting
 
 Rate limiting for persistent API tokens is **disabled by default**. When enabled, limits match the [official Screeps auth token docs](https://docs.screeps.com/auth-tokens.html#Rate-Limiting).

--- a/README.md
+++ b/README.md
@@ -75,10 +75,36 @@ serverConfig:
     preventSpawning: false
 ```
 
+# Auth token rate limiting
+
+Rate limiting for persistent API tokens is **disabled by default**. When enabled, limits match the [official Screeps auth token docs](https://docs.screeps.com/auth-tokens.html#Rate-Limiting).
+
+Enable via `.screepsrc`:
+
+```ini
+[auth]
+rateLimitEnabled = true
+ratelimit.global = 240,60
+ratelimit.GET.api.user.memory = 2880,86400
+ratelimit.GET.api.user.code = null
+```
+
+Key pattern: `ratelimit.<METHOD>.<path.with.dots>` (e.g. `ratelimit.GET.api.game.market.orders = 120,3600`). Value is `max,window` in seconds; `max` alone overrides only the limit count; `null` disables that bucket (`max: null`).
+
+```yaml
+serverConfig:
+  auth:
+    rateLimitEnabled: true
+    rateLimits:
+      global: { max: 240, window: 60 }
+      "GET /api/user/memory": { max: 2880 }
+      "GET /api/user/code": { max: null }
+```
+
 # API
 
 ### config.auth.config
-Resolved mod configuration (merged from `.screepsrc` and `config.yml`). Example: `config.auth.config.registerCpu`.
+Resolved mod configuration (merged from `.screepsrc` and `config.yml`). Examples: `config.auth.config.registerCpu`, `config.auth.config.rateLimitEnabled`, `config.auth.config.rateLimits`.
 
 ### config.auth.authUser(username,password)
 Returns a Promise, resolves to either the user object or `false`

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -117,6 +117,93 @@ function setupRouter (config) {
       .then(() => res.json({ ok: 1 }))
       .catch(err => res.json({ ok: 0, error: err.message }))
   })
+  router.get('/api/user/auth-token', authroute.tokenAuth, bodyParse, async (req, res) => {
+    if (!req.user) return res.status(401).send({ error: 'Unauthorized' })
+    const tokens = await config.auth.getUserTokens(req.user._id)
+    res.json({
+      ok: 1,
+      tokens: tokens.map(token => formatTokenForClient(token, { maskToken: true }))
+    })
+  })
+  router.post('/api/user/auth-token', authroute.tokenAuth, bodyParse, async (req, res) => {
+    if (!req.user) return res.status(401).send({ error: 'Unauthorized' })
+    const { type, description } = req.body
+    if (description && typeof description !== 'string') return res.status(400).send({ ok: 0, error: 'invalid description' })
+    const full = type !== 'selected'
+    try {
+      const token = await config.auth.createToken(req.user._id, {
+        full,
+        description,
+      })
+      res.json({ ok: 1, token })
+    } catch (e) {
+      res.status(400).send({ ok: 0, error: e.message })
+    }
+  })
+  router.post('/api/user/delete-auth-token', authroute.tokenAuth, bodyParse, async (req, res) => {
+    if (!req.user) return res.status(401).send({ error: 'Unauthorized' })
+    const { tokenId } = req.body
+    try {
+      await config.auth.deleteToken(req.user._id, tokenId)
+      res.json({ ok: 1 })
+    } catch (e) {
+      res.json({ error: String(e) })
+    }
+  })
+  router.post('/api/user/noratelimit', authroute.tokenAuth, bodyParse, async (req, res) => {
+    if (!req.user) return res.status(401).send({ error: 'Unauthorized' })
+    const { token } = req.body
+    try {
+      if (!await config.auth.removeTokenLimit(req.user._id, token)) {
+        res.status(404).send({ ok: 0 })
+        return
+      }
+      res.json({ ok: 1 })
+    } catch (e) {
+      res.status(400).send({ ok: 0, error: e.message })
+    }
+  })
+  function formatTokenForClient (tokenData, { maskToken = false } = {}) {
+    const info = {
+      _id: tokenData._id,
+      token: maskToken
+        ? tokenData.token.substring(0, 8) + '-****-****-****-************'
+        : tokenData.token,
+      full: !!tokenData.full,
+      description: tokenData.description ?? null
+    }
+    if (!tokenData.full) {
+      const endpoints = tokenData.endpoints || {}
+      info.endpoints = Object.keys(endpoints)
+        .filter(k => endpoints[k])
+        .map(k => k.replace('/api/game/', '/api/'))
+      const ws = tokenData.websockets || {}
+      info.websockets = ['console', 'rooms'].filter(k => ws[k])
+      const segments = tokenData.memorySegments
+      if (segments && segments.length) {
+        info.memorySegments = segments.map(String)
+      }
+    }
+    if (tokenData.noRatelimitUntil > Date.now()) {
+      info.noRatelimitUntil = tokenData.noRatelimitUntil
+    }
+    return info
+  }
+
+  async function handleQueryToken (token, res) {
+    if (!token) {
+      res.json({ error: 'token not found' })
+      return
+    }
+    const tokenData = await config.auth.queryToken(token)
+    if (!tokenData) {
+      res.json({ error: 'token not found' })
+      return
+    }
+    res.json({ ok: 1, token: formatTokenForClient(tokenData) })
+  }
+  router.get('/api/auth/query-token', (req, res) => handleQueryToken(req.query.token, res))
+  router.post('/api/auth/query-token', bodyParse, (req, res) => handleQueryToken(req.body.token, res))
   router.use('/authmod', express.static(path.join(__dirname, '/../static')))
   router.get('/api/authmod', (req, res) => res.json(Object.assign({ ok: 1 }, config.auth.info)))
   require('./register')(config)

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -7,6 +7,17 @@ const LocalStrategy = require('passport-local').Strategy
 const BasicStrategy = require('passport-http').BasicStrategy
 const authlib = require('@screeps/backend/lib/authlib')
 const authroute = require('@screeps/backend/lib/game/api/auth')
+const { checkAndConsume, setRateLimitHeaders } = require('./ratelimit')
+const { httpEndpointKey } = require('./http-endpoint')
+
+const RATE_LIMIT_EXEMPT = new Set([
+  'POST /api/user/noratelimit',
+  'GET /api/user/auth-token',
+  'POST /api/user/auth-token',
+  'POST /api/user/delete-auth-token',
+  'GET /api/auth/query-token',
+  'POST /api/auth/query-token'
+])
 
 /** Out-of-band storage for tokens when accessing websockets */
 const socketApiTokenByUserId = new Map()
@@ -67,6 +78,7 @@ module.exports = function (cconfig, authIns) {
   config.backend.on('expressPreConfig', function (app) {
     process.on('SIGTERM', () => process.exit())
     app.use(normalizeTokenCredentials)
+    app.use(createRateLimitMiddleware(config))
     app.use(config.auth.router)
   })
   config.backend.on('expressPostConfig', function () {
@@ -376,4 +388,35 @@ function bodyParse (req, res, next) {
 
 function authUser (username, password, done) {
   config.auth.authUser(username, password).then((res) => done(null, res)).catch(done)
+}
+
+function createRateLimitMiddleware (config) {
+  return async function rateLimitMiddleware (req, res, next) {
+    if (!config.auth.config.rateLimitEnabled) return next()
+
+    const endpointKey = httpEndpointKey(req)
+    if (RATE_LIMIT_EXEMPT.has(endpointKey)) return next()
+
+    const token = req.get('x-token') || (req.query && req.query._token)
+    if (!token) return next()
+
+    let apiToken
+    try {
+      apiToken = await config.auth.queryToken(token)
+    } catch (err) {
+      return next(err)
+    }
+    if (!apiToken) return next()
+
+    if (apiToken.noRatelimitUntil > Date.now()) return next()
+
+    const result = checkAndConsume(apiToken.token, endpointKey, config.auth.config.rateLimits)
+    if (!result.allowed) {
+      setRateLimitHeaders(res, result.headers)
+      res.status(429).type('text/plain').send(`Rate limit exceeded, retry after ${result.retryAfterMs}ms`)
+      return
+    }
+    if (result.headers) setRateLimitHeaders(res, result.headers)
+    next()
+  }
 }

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -17,6 +17,22 @@ const socketApiTokenByUserId = new Map()
  */
 const apiTokenPlainReuseQueues = new Map()
 
+function wrapSocketModule (config, modFactory) {
+  return function scopedSocketFactory (listen, emit) {
+    const socket = modFactory(listen, emit)
+    if (!socket.onSubscribe) return socket
+    const inner = socket.onSubscribe.bind(socket)
+    socket.onSubscribe = function onSubscribeScoped (channel, user, conn) {
+      const token = user && socketApiTokenByUserId.get(String(user._id))
+      if (token && !token.allowsWebsocket(channel, user)) {
+        return false
+      }
+      return inner(channel, user, conn)
+    }
+    return socket
+  }
+}
+
 BasicStrategy.prototype._challenge = function () { return '' }
 
 /** passport-token requires x-username and x-token; official API accepts either header or ?_token= alone. */
@@ -95,7 +111,7 @@ function setupRouter (config) {
     }
 
     const token = await config.auth.queryToken(tokenStr)
-    if (token && token.full) {
+    if (token) {
       const user = await config.auth.getUser(token.user)
       if (!user) return false
       const id = String(token.user)
@@ -111,6 +127,10 @@ function setupRouter (config) {
 
     return false
   }
+
+  config.backend.socketModules.user = wrapSocketModule(config, require('@screeps/backend/lib/game/socket/user'))
+  config.backend.socketModules.rooms = wrapSocketModule(config, require('@screeps/backend/lib/game/socket/rooms'))
+  config.backend.socketModules.map = wrapSocketModule(config, require('@screeps/backend/lib/game/socket/map'))
 
   originalTokenAuth = authroute.tokenAuth
   authroute.tokenAuth = tokenAuthProxy
@@ -261,13 +281,16 @@ function setupRouter (config) {
   })
   router.post('/api/user/auth-token', authroute.tokenAuth, bodyParse, async (req, res) => {
     if (!req.user) return res.status(401).send({ error: 'Unauthorized' })
-    const { type, description } = req.body
+    const { type, description, endpoints, websockets, memorySegments } = req.body
     if (description && typeof description !== 'string') return res.status(400).send({ ok: 0, error: 'invalid description' })
     const full = type !== 'selected'
     try {
       const token = await config.auth.createToken(req.user._id, {
         full,
         description,
+        endpoints,
+        websockets,
+        memorySegments
       })
       res.json({ ok: 1, token })
     } catch (e) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -2,14 +2,39 @@ const path = require('path')
 const express = require('express')
 const bodyParser = require('body-parser')
 const passport = require('passport')
+const TokenStrategy = require('passport-token').Strategy
 const LocalStrategy = require('passport-local').Strategy
 const BasicStrategy = require('passport-http').BasicStrategy
 const authlib = require('@screeps/backend/lib/authlib')
 const authroute = require('@screeps/backend/lib/game/api/auth')
 
+/** Out-of-band storage for tokens when accessing websockets */
+const socketApiTokenByUserId = new Map()
+
+/**
+ * FIFO queue for auth tokens.
+ * Ensures concurrent connections from the same user with different tokens each get their own token back.
+ */
+const apiTokenPlainReuseQueues = new Map()
+
 BasicStrategy.prototype._challenge = function () { return '' }
 
+/** passport-token requires x-username and x-token; official API accepts either header or ?_token= alone. */
+function normalizeTokenCredentials (req, res, next) {
+  const token = req.get('x-token') || (req.query && req.query._token)
+  if (!token) return next()
+  if (!req.get('x-token')) req.headers['x-token'] = token
+  if (!req.get('x-username')) req.headers['x-username'] = token
+  next()
+}
+
 let storage, config
+let tokenAuthImpl, originalTokenAuth
+
+/** Stable reference so routes registered after mod load always call the current implementation. */
+function tokenAuthProxy (request, response, next) {
+  return tokenAuthImpl(request, response, next)
+}
 
 module.exports = function (cconfig, authIns) {
   require('./cli')(cconfig)
@@ -25,12 +50,109 @@ module.exports = function (cconfig, authIns) {
   config.auth.router = new express.Router()
   config.backend.on('expressPreConfig', function (app) {
     process.on('SIGTERM', () => process.exit())
+    app.use(normalizeTokenCredentials)
     app.use(config.auth.router)
+  })
+  config.backend.on('expressPostConfig', function () {
+    passport.use('token', new TokenStrategy({ passReqToCallback: true }, (req, _email, token, done) => {
+      authlib.checkToken(token, false, req)
+        .then(user => done(null, user))
+        .catch((error) => (error === false ? done(null, false) : done(error)))
+    }))
   })
   setupRouter(config)
 }
 
 function setupRouter (config) {
+  const origGen = authlib.genToken.bind(authlib)
+  authlib.genToken = function genTokenWrapped (id) {
+    const k = String(id)
+    const q = apiTokenPlainReuseQueues.get(k)
+    if (q && q.length > 0) {
+      const plain = q.shift()
+      if (!q.length) apiTokenPlainReuseQueues.delete(k)
+      return Promise.resolve(plain)
+    }
+    return origGen(id)
+  }
+
+  const oldCheckToken = authlib.checkToken.bind(authlib)
+  authlib.checkToken = async function (tokenStr, noConsume, req) {
+    let legacyUser = false
+    try {
+      legacyUser = await oldCheckToken(tokenStr, noConsume)
+    } catch (err) {
+      // legacy session token miss
+    }
+    if (legacyUser) {
+      const id = String(legacyUser._id)
+      if (req) delete req.apiToken
+      else {
+        socketApiTokenByUserId.delete(id)
+        apiTokenPlainReuseQueues.delete(id)
+      }
+      return legacyUser
+    }
+
+    const token = await config.auth.queryToken(tokenStr)
+    if (token && token.full) {
+      const user = await config.auth.getUser(token.user)
+      if (!user) return false
+      const id = String(token.user)
+      if (req) req.apiToken = token
+      else {
+        socketApiTokenByUserId.set(id, token)
+        const q = apiTokenPlainReuseQueues.get(id) || []
+        q.push(tokenStr)
+        apiTokenPlainReuseQueues.set(id, q)
+      }
+      return user
+    }
+
+    return false
+  }
+
+  originalTokenAuth = authroute.tokenAuth
+  authroute.tokenAuth = tokenAuthProxy
+  tokenAuthImpl = async function tokenAuth (request, response, next) {
+    const token = request.get('x-token') || (request.query && request.query._token)
+    if (token) {
+      try {
+        const tokenData = await config.auth.queryToken(token)
+        if (tokenData) {
+          const user = await config.auth.getUser(tokenData.user)
+          if (!user) {
+            response.status(401).send({ error: 'unauthorized' })
+            return
+          }
+          request.user = user
+          request.apiToken = tokenData
+          if (!tokenData.allowsHTTP(request)) {
+            response.status(403).send({ error: 'forbidden' })
+            return
+          }
+          return next()
+        }
+      } catch (err) {
+        return next(err)
+      }
+    }
+    return originalTokenAuth(request, response, next)
+  }
+  // Patch upstream /api/auth/me to use the same token auth path as other endpoints.
+  const authRouterStack = authroute.router && authroute.router.stack
+  if (Array.isArray(authRouterStack)) {
+    for (const layer of authRouterStack) {
+      const route = layer && layer.route
+      if (!route || route.path !== '/me' || !route.methods || !route.methods.get) continue
+      const middleware = route.stack && route.stack[0]
+      if (middleware && typeof middleware.handle === 'function') {
+        middleware.handle = tokenAuthProxy
+      }
+      break
+    }
+  }
+
   passport.use(new LocalStrategy({
     usernameField: 'email',
     session: false
@@ -43,17 +165,29 @@ function setupRouter (config) {
   const router = config.auth.router
   router.use(passport.initialize())
   router.use((req, res, next) => {
-    const token = req.get('x-token')
-    if (token) {
-      authlib.checkToken(token, true)
+    const tokenStr = req.get('x-token')
+    if (tokenStr) {
+      authlib.checkToken(tokenStr, true, req)
         .then((user) => {
+          if (!user) {
+            next()
+            return
+          }
           req.headers['x-server-password'] = process.env.SERVER_PASSWORD || ''
-          return authlib.genToken(user._id)
-        })
-        .then((freshToken) => {
-          res.set('X-Token', freshToken)
-          res.set('X-Username', freshToken)
-          next()
+          const token = req.apiToken
+          if (token) {
+            if (!token.allowsHTTP(req)) {
+              res.status(403).json({ error: 'forbidden' })
+              return
+            }
+            next()
+            return
+          }
+          return authlib.genToken(user._id).then((freshToken) => {
+            res.set('X-Token', freshToken)
+            res.set('X-Username', freshToken)
+            next()
+          })
         })
         .catch(() => next())
     } else {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,9 +5,8 @@ module.exports = function (config) {
     setPassword: backendUtils.withHelp([
       'setPassword(username, password) - Set a user password for API login.',
       function setPassword (username, password) {
-        if (!username || !password) {
-          return 'Usage: auth.setPassword(username, password)'
-        }
+        if (!username) return 'Missing username'
+        if (!password) return 'Missing password'
         return config.auth.hashPassword(password)
           .then(({ pass, salt }) => {
             return config.common.storage.db.users.update({ username }, { $set: { password: pass, salt } })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,9 @@
 const backendUtils = require('@screeps/backend/lib/utils')
 
+function toIsoOrNull (value) {
+  return value ? new Date(value).toISOString() : null
+}
+
 module.exports = function (config) {
   const auth = {
     setPassword: backendUtils.withHelp([
@@ -26,6 +30,95 @@ module.exports = function (config) {
             if (description) opts.description = description
             return config.auth.createToken(user._id, opts)
           })
+      }
+    ]),
+    getTokenRateLimit: backendUtils.withHelp([
+      'getTokenRateLimit(username?) - Show currently active rate-limit usage per token (optionally for one user).',
+      async function getTokenRateLimit (username) {
+        const limits = config.auth.getRateLimits()
+        if (!limits) return []
+
+        try {
+          const now = Date.now()
+          let userId
+          if (username) {
+            const user = await config.common.storage.db.users.findOne({ username })
+            if (!user) return 'No such user'
+            userId = user._id
+          }
+          const activity = await config.auth.getRateLimitActivity(userId)
+          return activity.map(({ token, buckets }) => {
+            const noRatelimitUntil = token.noRatelimitUntil || 0
+            const noRatelimitRemainingMs = Math.max(0, noRatelimitUntil - now)
+            return {
+              tokenId: token._id,
+              token: token.token,
+              user: token.user,
+              ...(token.description ? { description: token.description } : {}),
+              ...(noRatelimitRemainingMs > 0
+                ? {
+                    noRatelimit: {
+                      remainingMs: noRatelimitRemainingMs,
+                      until: noRatelimitUntil,
+                      untilISO: toIsoOrNull(noRatelimitUntil)
+                    }
+                  }
+                : {}),
+              rateLimits: buckets.map(bucket => {
+                const resetAtISO = toIsoOrNull(bucket.resetAt)
+                const isLimited = bucket.remaining === 0
+                return {
+                  bucket: bucket.key,
+                  count: bucket.count,
+                  limit: bucket.limit,
+                  remaining: bucket.remaining,
+                  window: bucket.window,
+                  resetAt: bucket.resetAt,
+                  resetAtISO,
+                  ...(isLimited
+                    ? {
+                        retryAfterMs: bucket.retryAfterMs,
+                        limitedUntil: bucket.resetAt,
+                        limitedUntilISO: resetAtISO
+                      }
+                    : {})
+                }
+              })
+            }
+          })
+        } catch (err) {
+          return {
+            error: err.message
+          }
+        }
+      }
+    ]),
+    listUserTokenRateLimits: backendUtils.withHelp([
+      'listUserTokenRateLimits(username) - List current no-ratelimit status for all user tokens.',
+      async function listUserTokenRateLimits (username) {
+        if (!username) return 'Missing username'
+        const user = await config.common.storage.db.users.findOne({ username })
+        if (!user) return 'No such user'
+        const tokens = await config.auth.getUserTokens(user._id)
+        const now = Date.now()
+        return tokens.map(token => {
+          const noRatelimitUntil = token.noRatelimitUntil || 0
+          const noRatelimitRemainingMs = Math.max(0, noRatelimitUntil - now)
+          return {
+            tokenId: token._id,
+            token: token.token,
+            ...(token.description ? { description: token.description } : {}),
+            ...(noRatelimitRemainingMs > 0
+              ? {
+                  noRatelimit: {
+                    remainingMs: noRatelimitRemainingMs,
+                    until: noRatelimitUntil,
+                    untilISO: toIsoOrNull(noRatelimitUntil)
+                  }
+                }
+              : {})
+          }
+        })
       }
     ])
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,6 +12,21 @@ module.exports = function (config) {
             return config.common.storage.db.users.update({ username }, { $set: { password: pass, salt } })
           })
       }
+    ]),
+    createAuthToken: backendUtils.withHelp([
+      'createAuthToken(username, description?) - Create a full auth token for the given user',
+      function createAuthToken (username, description) {
+        if (!username) {
+          return 'Missing username'
+        }
+        return config.common.storage.db.users.findOne({ username })
+          .then(user => {
+            if (!user) return 'No such user'
+            const opts = { full: true }
+            if (description) opts.description = description
+            return config.auth.createToken(user._id, opts)
+          })
+      }
     ])
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,10 +1,14 @@
 const fs = require('fs')
 const ini = require('ini')
+const { DEFAULT_RATE_LIMITS } = require('./ratelimit')
 
 const DEFAULT_AUTH = {
   registerCpu: 100,
-  preventSpawning: false
+  preventSpawning: false,
+  rateLimitEnabled: false
 }
+
+const RATELIMIT_PREFIX = 'ratelimit.'
 
 function truthy (v) {
   if (v === true || v === 1) return true
@@ -31,6 +35,54 @@ function parseScreepsrc () {
   const result = {}
   if (auth.registerCpu != null) result.registerCpu = normalizeCpu(auth.registerCpu)
   if (auth.preventSpawning != null) result.preventSpawning = truthy(auth.preventSpawning)
+  if (auth.rateLimitEnabled != null) result.rateLimitEnabled = truthy(auth.rateLimitEnabled)
+
+  function parseKey (suffix) {
+    if (suffix === 'global') return 'global'
+    const dot = suffix.indexOf('.')
+    if (dot === -1) return null
+    const method = suffix.slice(0, dot)
+    const pathDots = suffix.slice(dot + 1)
+    if (!method || !pathDots) return null
+    return `${method.toUpperCase()} /${pathDots.replace(/\./g, '/')}`
+  }
+
+  function parseValue (value) {
+    if (value == null) return null
+    const s = String(value).trim()
+    if (!s || s.toLowerCase() === 'null') return { max: null }
+    const parts = s.split(',').map(x => x.trim())
+    const max = parseInt(parts[0], 10)
+    if (Number.isNaN(max) || max < 1) {
+      console.warn(`[screepsmod-auth] invalid ratelimit max "${parts[0]}", skipping value`)
+      return null
+    }
+    const out = { max }
+    if (parts.length > 1 && parts[1] !== '') {
+      const window = parseInt(parts[1], 10)
+      if (Number.isNaN(window) || window < 1) {
+        console.warn(`[screepsmod-auth] invalid ratelimit window "${parts[1]}", using default window`)
+      } else {
+        out.window = window
+      }
+    }
+    return out
+  }
+
+  const rateLimits = {}
+  for (const [key, rawValue] of Object.entries(auth)) {
+    if (!key.startsWith(RATELIMIT_PREFIX)) continue
+
+    const bucketKey = parseKey(key.slice(RATELIMIT_PREFIX.length))
+    if (!bucketKey) {
+      console.warn(`[screepsmod-auth] invalid ratelimit key "${key}", skipping`)
+      continue
+    }
+    const parsed = parseValue(rawValue)
+    if (parsed) rateLimits[bucketKey] = parsed
+  }
+
+  if (Object.keys(rateLimits).length) result.rateLimits = rateLimits
   return result
 }
 
@@ -62,15 +114,85 @@ function parseConfigYml (source) {
   const result = {}
   if (auth.registerCpu != null) result.registerCpu = normalizeCpu(auth.registerCpu)
   if (auth.preventSpawning != null) result.preventSpawning = truthy(auth.preventSpawning)
+  if ('rateLimitEnabled' in auth) result.rateLimitEnabled = truthy(auth.rateLimitEnabled)
+
+  if (auth.rateLimits && typeof auth.rateLimits === 'object') {
+    function normalizeEntry (entry) {
+      if (entry == null) return null
+      if (typeof entry !== 'object') return null
+      const out = {}
+      if ('max' in entry) {
+        if (entry.max === null || entry.max === false) {
+          out.max = null
+        } else {
+          const max = typeof entry.max === 'number' ? entry.max : parseInt(entry.max, 10)
+          if (Number.isNaN(max) || max < 1) {
+            console.warn('[screepsmod-auth] invalid rateLimits max, skipping field')
+          } else {
+            out.max = max
+          }
+        }
+      }
+      if ('window' in entry && entry.window != null) {
+        const window = typeof entry.window === 'number' ? entry.window : parseInt(entry.window, 10)
+        if (Number.isNaN(window) || window < 1) {
+          console.warn('[screepsmod-auth] invalid rateLimits window, skipping field')
+        } else {
+          out.window = window
+        }
+      }
+      return Object.keys(out).length ? out : null
+    }
+
+    const rateLimits = {}
+    for (const [key, entry] of Object.entries(auth.rateLimits)) {
+      const normalized = normalizeEntry(entry)
+      if (normalized) rateLimits[key] = normalized
+    }
+    if (Object.keys(rateLimits).length) result.rateLimits = rateLimits
+  }
+
   return result
 }
 
 function mergeAuthConfig (fromScreepsrc, fromYaml) {
   const screepsrc = fromScreepsrc || {}
   const yaml = fromYaml || {}
+  const overrides = {
+    ...(screepsrc.rateLimits || {}),
+    ...(yaml.rateLimits || {})
+  }
+
+  function buildActiveLimits () {
+    function mergeLimitEntry (base, override) {
+      if (!override) return base
+      if (override.max === null) return null
+      if (!base && override.max != null) {
+        if (override.window == null) return null
+        return { max: override.max, window: override.window }
+      }
+      if (!base) return null
+      const merged = { ...base, ...override }
+      if (merged.max == null) return null
+      return merged
+    }
+
+    const active = {}
+    const keys = new Set([...Object.keys(DEFAULT_RATE_LIMITS), ...Object.keys(overrides)])
+    for (const key of keys) {
+      const base = DEFAULT_RATE_LIMITS[key] || null
+      const override = overrides[key] || null
+      const merged = mergeLimitEntry(base, override)
+      if (merged) active[key] = merged
+    }
+    return active
+  }
+
   return {
     registerCpu: yaml.registerCpu ?? screepsrc.registerCpu ?? DEFAULT_AUTH.registerCpu,
-    preventSpawning: yaml.preventSpawning ?? screepsrc.preventSpawning ?? DEFAULT_AUTH.preventSpawning
+    preventSpawning: yaml.preventSpawning ?? screepsrc.preventSpawning ?? DEFAULT_AUTH.preventSpawning,
+    rateLimitEnabled: yaml.rateLimitEnabled ?? screepsrc.rateLimitEnabled ?? DEFAULT_AUTH.rateLimitEnabled,
+    rateLimits: buildActiveLimits()
   }
 }
 

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -54,7 +54,7 @@ module.exports = function (config) {
     let user = null
     const token = req.cookies.auth_token
     res.clearCookie('auth_token')
-    if (token) user = authlib.checkToken(token)
+    if (token) user = authlib.checkToken(token, false, req)
     githubFindOrCreateUser(user, req.user)
       .then(user => authlib.genToken(user._id))
       .then(token => {

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -56,7 +56,7 @@ module.exports = function (config) {
     let user = null
     const token = req.cookies.auth_token
     res.clearCookie('auth_token')
-    if (token) user = authlib.checkToken(token)
+    if (token) user = authlib.checkToken(token, false, req)
     gitlabFindOrCreateUser(user, req.user)
       .then(user => authlib.genToken(user._id))
       .then(token => {

--- a/lib/http-endpoint.js
+++ b/lib/http-endpoint.js
@@ -1,0 +1,15 @@
+function normalizePathOnly (url) {
+  if (!url) return '/'
+  const p = ('' + url).split('?')[0] || '/'
+  return p.replace(/\/{2,}/g, '/') || '/'
+}
+
+function httpEndpointKey (req) {
+  const pathOnly = normalizePathOnly(req.originalUrl || req.url || '')
+  return `${(req.method || 'GET').toUpperCase()} ${pathOnly}`
+}
+
+module.exports = {
+  normalizePathOnly,
+  httpEndpointKey
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,92 @@
 const Auth = require('./auth')
 const crypto = require('crypto')
+const { httpEndpointKey } = require('./http-endpoint')
+
+/** Keys match the official UI / account token JSON (method + space + path under /api). */
+const API_ENDPOINTS = new Set([
+  'GET /api/user/name',
+  'GET /api/user/money-history',
+  'GET /api/user/memory',
+  'POST /api/user/memory',
+  'GET /api/user/memory-segment',
+  'POST /api/user/memory-segment',
+  'GET /api/game/market/orders-index',
+  'GET /api/game/market/orders',
+  'GET /api/game/market/my-orders',
+  'GET /api/game/market/stats'
+])
+
+/** Official client sends shortened API paths */
+const API_ENDPOINT_ALIASES = {
+  'GET /api/market/orders-index': 'GET /api/game/market/orders-index',
+  'GET /api/market/orders': 'GET /api/game/market/orders',
+  'GET /api/market/my-orders': 'GET /api/game/market/my-orders',
+  'GET /api/market/stats': 'GET /api/game/market/stats'
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number[]|null} non-empty list = only these segment ids; null = all segments (blank field in UI)
+ */
+function parseMemorySegments (value) {
+  if (value === null || value === undefined) return null
+  const s = typeof value === 'string' ? value.trim() : ''
+  if (!s) return null
+  const parts = s.split(/[\s,]+/).map(x => x.trim()).filter(Boolean)
+  const ids = []
+  for (const p of parts) {
+    const n = parseInt(p, 10)
+    if (Number.isNaN(n) || n < 0 || n > 99) {
+      throw new Error('invalid memory segment id')
+    }
+    ids.push(n)
+  }
+  return ids
+}
 
 function tokenAllowsHTTP (req) {
   if (this.full) return true
-  return false
+
+  const key = httpEndpointKey(req)
+  if (!this.endpoints || !this.endpoints[key]) return false
+
+  const ids = this.memorySegments
+  if (!ids || !ids.length) return true
+
+  let segment = null
+  if (key === 'GET /api/user/memory-segment') {
+    segment = parseInt(req.query && req.query.segment, 10)
+  } else if (key === 'POST /api/user/memory-segment') {
+    segment = parseInt(req.body && req.body.segment, 10)
+  } else {
+    return true
+  }
+  if (Number.isNaN(segment)) return false
+  return ids.includes(segment)
 }
 
 function tokenAllowsWebsocket (channel, user) {
   if (this.full) return true
+  if (!user) return false
+
+  if (channel === 'server-message') return true
+
+  const uid = String(user._id)
+
+  if (/^user:.+\/console$/.test(channel)) {
+    const websockets = this.websockets || {}
+    return !!(websockets.console && channel.startsWith(`user:${uid}/`))
+  }
+  if (/^user:.+\/memory\//.test(channel)) {
+    const endpoints = this.endpoints || {}
+    if (!endpoints['GET /api/user/memory']) return false
+    return channel.startsWith(`user:${uid}/`)
+  }
+  if (/^room:/.test(channel) || /^roomMap2:/.test(channel)) {
+    const websockets = this.websockets || {}
+    return !!websockets.rooms
+  }
+
   return false
 }
 
@@ -46,6 +125,7 @@ module.exports = function (config) {
 
   const auth = new Auth()
   config.auth = {
+    httpEndpointKey,
     checkPassword (salt, pass, proposed) {
       return auth.verify_password(salt, pass, proposed)
     },
@@ -103,9 +183,19 @@ module.exports = function (config) {
       const {
         full = true,
         description = null,
+        endpoints,
+        websockets,
+        memorySegments
       } = opts
       if (!await this.getUser(userId)) throw new Error('No such user')
-      if (!full) throw new Error('Only full tokens supported')
+      let memorySegmentIds = null
+      if (!full) {
+        try {
+          memorySegmentIds = parseMemorySegments(memorySegments)
+        } catch (e) {
+          throw new Error('invalid memorySegments')
+        }
+      }
       let uuid
       do {
         uuid = crypto.randomUUID()
@@ -117,6 +207,22 @@ module.exports = function (config) {
         full,
         token: uuid,
         noRatelimitUntil: Date.now()
+      }
+      if (!full) {
+        const endpointsOut = {}
+        if (endpoints && typeof endpoints === 'object') {
+          for (const k of Object.keys(endpoints)) {
+            const canonical = API_ENDPOINT_ALIASES[k] || k
+            if (API_ENDPOINTS.has(canonical) && endpoints[k]) endpointsOut[canonical] = true
+          }
+        }
+        token.endpoints = endpointsOut
+        const ws = websockets && typeof websockets === 'object' ? websockets : {}
+        token.websockets = {
+          console: !!ws.console,
+          rooms: !!ws.rooms
+        }
+        token.memorySegments = memorySegmentIds && memorySegmentIds.length ? memorySegmentIds : null
       }
       await config.common.storage.db['users.tokens'].insert(token)
       return uuid

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,37 @@
 const Auth = require('./auth')
 const crypto = require('crypto')
 
+function tokenAllowsHTTP (req) {
+  if (this.full) return true
+  return false
+}
+
+function tokenAllowsWebsocket (channel, user) {
+  if (this.full) return true
+  return false
+}
+
+function withTokenMethods (token) {
+  if (!token || typeof token !== 'object') return token
+  if (typeof token.allowsHTTP !== 'function') {
+    Object.defineProperty(token, 'allowsHTTP', {
+      value: tokenAllowsHTTP,
+      enumerable: false,
+      configurable: true,
+      writable: true
+    })
+  }
+  if (typeof token.allowsWebsocket !== 'function') {
+    Object.defineProperty(token, 'allowsWebsocket', {
+      value: tokenAllowsWebsocket,
+      enumerable: false,
+      configurable: true,
+      writable: true
+    })
+  }
+  return token
+}
+
 module.exports = function (config) {
   // Token db setup
   config.common.dbCollections.push('users.tokens')
@@ -66,7 +97,7 @@ module.exports = function (config) {
     async getUserTokens (userId) {
       if (!await this.getUser(userId)) throw new Error('No such user')
       const tokens = await config.common.storage.db['users.tokens'].find({ user: userId })
-      return tokens
+      return tokens.map(withTokenMethods)
     },
     async createToken (userId, opts = {}) {
       const {
@@ -95,7 +126,7 @@ module.exports = function (config) {
       const tokenData = await config.common.storage.db['users.tokens'].findOne({ token: tokenId })
       if (!tokenData) return null
       if (!await this.getUser(tokenData.user)) return null
-      return tokenData
+      return withTokenMethods(tokenData)
     },
     async removeTokenLimit (userId, tokenPrefix) {
       const token = (await this.getUserTokens(userId)).find(t => t.token.startsWith(tokenPrefix))

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,18 @@
 const Auth = require('./auth')
+const crypto = require('crypto')
 
 module.exports = function (config) {
+  // Token db setup
+  config.common.dbCollections.push('users.tokens')
+  config.common.dbIndexes ??= {}
+  config.common.dbIndexes['users.tokens'] = { user: 1 }
+
+  if (config.mongo) {
+    // MongoDB mode
+    const db = config.mongo.client.db()
+    db.createCollection('users.tokens', 'user')
+  }
+
   const auth = new Auth()
   config.auth = {
     checkPassword (salt, pass, proposed) {
@@ -50,6 +62,52 @@ module.exports = function (config) {
     },
     getGroups (filter) {
       return Promise.resolve([{ name: 'admin' }])
+    },
+    async getUserTokens (userId) {
+      if (!await this.getUser(userId)) throw new Error('No such user')
+      const tokens = await config.common.storage.db['users.tokens'].find({ user: userId })
+      return tokens
+    },
+    async createToken (userId, opts = {}) {
+      const {
+        full = true,
+        description = null,
+      } = opts
+      if (!await this.getUser(userId)) throw new Error('No such user')
+      if (!full) throw new Error('Only full tokens supported')
+      let uuid
+      do {
+        uuid = crypto.randomUUID()
+      } while (await config.common.storage.db['users.tokens'].findOne({ token: uuid }))
+
+      const token = {
+        user: userId,
+        description,
+        full,
+        token: uuid,
+        noRatelimitUntil: Date.now()
+      }
+      await config.common.storage.db['users.tokens'].insert(token)
+      return uuid
+    },
+    async queryToken (tokenId) {
+      if (!tokenId) return null
+      const tokenData = await config.common.storage.db['users.tokens'].findOne({ token: tokenId })
+      if (!tokenData) return null
+      if (!await this.getUser(tokenData.user)) return null
+      return tokenData
+    },
+    async removeTokenLimit (userId, tokenPrefix) {
+      const token = (await this.getUserTokens(userId)).find(t => t.token.startsWith(tokenPrefix))
+      if (!token) return false
+      const noRatelimitUntil = Date.now() + 2 * 60 * 60 * 1000
+      await config.common.storage.db['users.tokens'].update(token, { $set: { noRatelimitUntil } })
+      return true
+    },
+    async deleteToken (userId, tokenId) {
+      if (!tokenId) return false
+      await config.common.storage.db['users.tokens'].remove({ _id: tokenId, user: userId })
+      return true
     }
   }
   require('./config')(config)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const Auth = require('./auth')
 const crypto = require('crypto')
 const { httpEndpointKey } = require('./http-endpoint')
+const { getTokenRateLimitState, getActiveTokenRateLimitState } = require('./ratelimit')
 
 /** Keys match the official UI / account token JSON (method + space + path under /api). */
 const API_ENDPOINTS = new Set([
@@ -233,6 +234,32 @@ module.exports = function (config) {
       if (!tokenData) return null
       if (!await this.getUser(tokenData.user)) return null
       return withTokenMethods(tokenData)
+    },
+    getRateLimits () {
+      if (!this.config.rateLimitEnabled) return null
+      return this.config.rateLimits
+    },
+    getTokenRateLimitState (tokenId) {
+      return getTokenRateLimitState(tokenId, this.getRateLimits())
+    },
+    async getRateLimitActivity (userId) {
+      const limits = this.getRateLimits()
+      if (!limits) return []
+
+      const tokenSnapshots = getActiveTokenRateLimitState(limits)
+      if (!tokenSnapshots.length) return []
+
+      const details = await Promise.all(tokenSnapshots.map(async (snapshot) => {
+        const token = await this.queryToken(snapshot.tokenId)
+        if (!token) return null
+        if (userId && String(token.user) !== String(userId)) return null
+        return {
+          token,
+          buckets: snapshot.buckets
+        }
+      }))
+
+      return details.filter(Boolean)
     },
     async removeTokenLimit (userId, tokenPrefix) {
       const token = (await this.getUserTokens(userId)).find(t => t.token.startsWith(tokenPrefix))

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -10,6 +10,7 @@ module.exports = config => {
       name: 'auth',
       version: 1
     },
+    { name: 'auth-tokens' },
     {
       name: 'screepsmod-auth',
       version: require('../package.json').version,

--- a/lib/ratelimit.js
+++ b/lib/ratelimit.js
@@ -131,9 +131,69 @@ function checkAndConsume (tokenId, endpointKey, limits) {
   return { allowed: true, headers: report, retryAfterMs: 0 }
 }
 
+function getTokenRateLimitState (tokenId, limits) {
+  if (!tokenId) return []
+  if (!limits || typeof limits !== 'object') return []
+
+  const now = Date.now()
+  const keys = Object.keys(limits).sort((a, b) => {
+    if (a === 'global') return -1
+    if (b === 'global') return 1
+    return a.localeCompare(b)
+  })
+
+  return keys.map((key) => {
+    const limit = limits[key]
+    const bucket = buckets.get(bucketKey(tokenId, key))
+    const activeBucket = bucket && now < bucket.resetAt ? bucket : null
+    const count = activeBucket ? activeBucket.count : 0
+    const remaining = Math.max(0, limit.max - count)
+    return {
+      key,
+      limit: limit.max,
+      window: limit.window,
+      count,
+      remaining,
+      resetAt: activeBucket ? activeBucket.resetAt : null,
+      retryAfterMs: remaining > 0 || !activeBucket ? 0 : Math.max(0, activeBucket.resetAt - now)
+    }
+  })
+}
+
+function getActiveTokenRateLimitState (limits) {
+  if (!limits || typeof limits !== 'object') return []
+
+  const now = Date.now()
+  const tokenIds = new Set()
+
+  for (const key of buckets.keys()) {
+    const bucket = buckets.get(key)
+    if (!bucket || now >= bucket.resetAt) {
+      buckets.delete(key)
+      continue
+    }
+
+    const separatorIndex = key.indexOf(':')
+    if (separatorIndex === -1) continue
+    const limitKey = key.slice(separatorIndex + 1)
+    if (!limits[limitKey]) continue
+    tokenIds.add(key.slice(0, separatorIndex))
+  }
+
+  return Array.from(tokenIds)
+    .sort((a, b) => a.localeCompare(b))
+    .map(tokenId => {
+      const activeBuckets = getTokenRateLimitState(tokenId, limits).filter(bucket => bucket.count > 0)
+      return activeBuckets.length ? { tokenId, buckets: activeBuckets } : null
+    })
+    .filter(Boolean)
+}
+
 module.exports = {
   DEFAULT_RATE_LIMITS,
   checkAndConsume,
   setRateLimitHeaders,
-  lookupConfiguredLimit
+  lookupConfiguredLimit,
+  getTokenRateLimitState,
+  getActiveTokenRateLimitState
 }

--- a/lib/ratelimit.js
+++ b/lib/ratelimit.js
@@ -1,0 +1,139 @@
+/** Official limits from https://docs.screeps.com/auth-tokens.html#Rate-Limiting */
+const DEFAULT_RATE_LIMITS = {
+  global: { max: 120, window: 60 },
+  'GET /api/game/room-terrain': { max: 360, window: 3600 },
+  'POST /api/game/map-stats': { max: 60, window: 3600 },
+  'GET /api/user/code': { max: 60, window: 3600 },
+  'POST /api/user/code': { max: 240, window: 86400 },
+  'POST /api/user/set-active-branch': { max: 240, window: 86400 },
+  'GET /api/user/memory': { max: 1440, window: 86400 },
+  'POST /api/user/memory': { max: 240, window: 86400 },
+  'GET /api/user/memory-segment': { max: 360, window: 3600 },
+  'POST /api/user/memory-segment': { max: 60, window: 3600 },
+  'POST /api/user/console': { max: 360, window: 3600 },
+  'GET /api/game/market/orders-index': { max: 60, window: 3600 },
+  'GET /api/game/market/orders': { max: 60, window: 3600 },
+  'GET /api/game/market/my-orders': { max: 60, window: 3600 },
+  'GET /api/game/market/stats': { max: 60, window: 3600 },
+  'GET /api/game/user/money-history': { max: 60, window: 3600 },
+  'GET /api/user/money-history': { max: 60, window: 3600 }
+}
+
+const buckets = new Map()
+
+function bucketKey (tokenId, limitKey) {
+  return `${tokenId}:${limitKey}`
+}
+
+function getBucket (tokenId, limitKey, windowSec) {
+  const key = bucketKey(tokenId, limitKey)
+  const now = Date.now()
+  let bucket = buckets.get(key)
+  if (!bucket || now >= bucket.resetAt) {
+    bucket = { count: 0, resetAt: now + windowSec * 1000 }
+    buckets.set(key, bucket)
+  }
+  return bucket
+}
+
+function rateLimitKeyVariants (endpointKey) {
+  const variants = [endpointKey]
+  const withGame = /^(\S+) (\/api)\/game(\/.+)$/.exec(endpointKey)
+  if (withGame) {
+    variants.push(`${withGame[1]} ${withGame[2]}${withGame[3]}`)
+  } else {
+    const withoutGame = /^(\S+) (\/api)(\/(?!game\/).+)$/.exec(endpointKey)
+    if (withoutGame) {
+      variants.push(`${withoutGame[1]} ${withoutGame[2]}/game${withoutGame[3]}`)
+    }
+  }
+  return variants
+}
+
+function lookupConfiguredLimit (limits, endpointKey) {
+  for (const variant of rateLimitKeyVariants(endpointKey)) {
+    if (limits[variant]) return { key: variant, limit: limits[variant] }
+  }
+  return null
+}
+
+function previewBucket (tokenId, limitKey, { max, window }) {
+  const bucket = getBucket(tokenId, limitKey, window)
+  const resetSec = Math.ceil(bucket.resetAt / 1000)
+  const remaining = Math.max(0, max - bucket.count)
+  const allowed = bucket.count < max
+  return {
+    allowed,
+    limit: max,
+    remaining: allowed ? remaining - 1 : remaining,
+    reset: resetSec,
+    retryAfterMs: allowed ? 0 : Math.max(0, bucket.resetAt - Date.now())
+  }
+}
+
+function pickTighter (a, b) {
+  if (!a) return b
+  if (!b) return a
+  if (!a.allowed) return a
+  if (!b.allowed) return b
+  return a.remaining <= b.remaining ? a : b
+}
+
+function setRateLimitHeaders (res, result) {
+  if (!result) return
+  res.set('X-RateLimit-Limit', String(result.limit))
+  res.set('X-RateLimit-Remaining', String(Math.max(0, result.remaining)))
+  res.set('X-RateLimit-Reset', String(result.reset))
+}
+
+function checkAndConsume (tokenId, endpointKey, limits) {
+  const applicable = []
+
+  if (limits.global) {
+    applicable.push({ key: 'global', limit: limits.global })
+  }
+
+  const endpoint = lookupConfiguredLimit(limits, endpointKey)
+  if (endpoint) {
+    applicable.push({ key: endpoint.key, limit: endpoint.limit })
+  }
+
+  if (!applicable.length) {
+    return { allowed: true, headers: null, retryAfterMs: 0 }
+  }
+
+  const previews = applicable.map(({ key, limit }) => previewBucket(tokenId, key, limit))
+  const rejected = previews.find(p => !p.allowed)
+  if (rejected) {
+    return { allowed: false, headers: rejected, retryAfterMs: rejected.retryAfterMs }
+  }
+
+  for (const { key, limit } of applicable) {
+    getBucket(tokenId, key, limit.window).count++
+  }
+
+  const post = applicable.map(({ key, limit }) => {
+    const bucket = getBucket(tokenId, key, limit.window)
+    return {
+      allowed: true,
+      limit: limit.max,
+      remaining: Math.max(0, limit.max - bucket.count),
+      reset: Math.ceil(bucket.resetAt / 1000),
+      retryAfterMs: 0
+    }
+  })
+
+  let report = post[0]
+  for (let i = 1; i < post.length; i++) {
+    report = pickTighter(report, post[i])
+  }
+
+  return { allowed: true, headers: report, retryAfterMs: 0 }
+}
+
+module.exports = {
+  DEFAULT_RATE_LIMITS,
+  checkAndConsume,
+  setRateLimitHeaders,
+  lookupConfiguredLimit
+}

--- a/lib/steam/index.js
+++ b/lib/steam/index.js
@@ -33,7 +33,7 @@ module.exports = function (config) {
         const [steamId] = identifier.split('/').slice(-1)
         let user = null
         const token = req.cookies.auth_token
-        if (token) user = authlib.checkToken(token)
+        if (token) user = authlib.checkToken(token, false, req)
         steamFindOrCreateUser(user, steamId)
           .then(user => done(null, user))
           .catch(err => done(err))


### PR DESCRIPTION
This adds the necessary support to handle auth tokens and ratelimits akin to the official server.

The one issue is that the client is hardcoded to expect the server to be official to show the token management page, but nothing a [Steamless patch](https://github.com/screepers/steamless-client/pull/82) can't fix.

Core API was written by hand, but I did polish up the details of the rate-limiting using Cursor, so here's your "LLM inside" warning.