### PR TITLE
Add more options for registering users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Circle CI](https://circleci.com/gh/ScreepsMods/screepsmod-auth.svg?style=shield)](https://circleci.com/gh/ScreepsMods/screepsmod-auth)
 
-# Installation 
+# Installation
 
 1. `npm install screepsmod-auth` in your server folder.
 2. Thats it!
@@ -47,7 +47,7 @@ Clients connecting to the server must send this password (for example via the `X
 
 Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in the environment.
 
-Make sure to set the callback url to point to `/api/auth/github/return` on your server. ex: `https://screeps.mydomain.com/api/auth/github/return`  
+Make sure to set the callback url to point to `/api/auth/github/return` on your server. ex: `https://screeps.mydomain.com/api/auth/github/return`
 Get the id and secret from your Github settings: https://github.com/settings/developers
 
 ## GitLab Auth
@@ -109,7 +109,18 @@ serverConfig:
       "GET /api/user/code": { max: null }
 ```
 
-# API
+# CLI commands
+
+This mod exposes a number of CLI commands via the `auth` namespace.
+
+Run the command `help(auth)` to get a list of commands:
+- `auth.createUser(username, opts?)` - Create a new user account. `opts` can be used to set additional user fields (ex: `email`). No authentication method is configured by default, so this command should typically be followed by `setPassword()`.
+- `auth.setPassword(username, password)` - Set a user's password for login and API authentication
+- `auth.createAuthToken(username, description?)` - Creates a full-access API token for a given user
+- `auth.listUserTokenRateLimits(username)` - Lists all tokens for a user and active no-ratelimit windows.
+- `auth.getTokenRateLimit(username?)` - Shows currently active rate-limit usage per token (optionally scoped to one user).
+
+# API endpoints
 
 ### config.auth.config
 Resolved mod configuration (merged from `.screepsrc` and `config.yml`). Examples: `config.auth.config.registerCpu`, `config.auth.config.rateLimitEnabled`, `config.auth.config.rateLimits`.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,6 +6,45 @@ function toIsoOrNull (value) {
 
 module.exports = function (config) {
   const auth = {
+    createUser: backendUtils.withHelp([
+      'createUser(username, opts?) - Create a new user account. `opts` can be used to set additional user fields (ex: `email`). No authentication method is configured by default, so this command should typically be followed by `setPassword()`.',
+      function createUser (username, opts) {
+        if (!username) return 'Missing username'
+        const { registerCpu } = config.auth.config
+        const usernameLower = username.toLowerCase()
+        const user = {
+          cpu: registerCpu,
+          cpuAvailable: 0,
+          registeredDate: new Date(),
+          money: 0,
+          gcl: 0,
+          powerExperimentations: 30,
+          ...(opts ?? {}),
+          username,
+          usernameLower
+        }
+        const modules = user.modules
+        delete user.modules
+        let query = { usernameLower }
+        if (user.email) query = { $or: [query, { email: user.email }] }
+        return config.common.storage.db.users.findOne(query)
+          .then((existingUser) => {
+            if (existingUser) return 'User exists'
+            return config.common.storage.db.users.insert(user)
+              .then(result => config.common.storage.db['users.code'].insert({
+                user: result._id,
+                modules: modules || { main: '' },
+                branch: 'default',
+                activeWorld: true,
+                activeSim: true
+              }))
+              .then(() => config.common.storage.env.set('scrUserMemory:' + user._id, JSON.stringify({})))
+              .then(() => 'Created new user')
+              .catch(err => ({ error: err.stack || err.message || err }))
+          })
+          .catch(err => ({ error: err.stack || err.message || err }))
+      }
+    ]),
     setPassword: backendUtils.withHelp([
       'setPassword(username, password) - Set a user password for API login.',
       function setPassword (username, password) {

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -86,7 +86,8 @@ module.exports = function (config) {
           cpuAvailable: 0,
           registeredDate: new Date(),
           money: 0,
-          gcl: 0
+          gcl: 0,
+          powerExperimentations: 30
         }
         return db.users.insert(user)
           .then(result => {

--- a/lib/gitlab/index.js
+++ b/lib/gitlab/index.js
@@ -88,7 +88,8 @@ module.exports = function (config) {
           cpuAvailable: 0,
           registeredDate: new Date(),
           money: 0,
-          gcl: 0
+          gcl: 0,
+          powerExperimentations: 30
         }
         return db.users.insert(user)
           .then(result => {

--- a/lib/register.js
+++ b/lib/register.js
@@ -27,7 +27,8 @@ module.exports = function (config) {
       registeredDate: new Date(),
       blocked: !!preventSpawning,
       money: 0,
-      gcl: 0
+      gcl: 0,
+      powerExperimentations: 30
     }
     if (process.env.SERVER_PASSWORD) {
       return res.json({

--- a/lib/steam/index.js
+++ b/lib/steam/index.js
@@ -75,7 +75,8 @@ module.exports = function (config) {
           cpuAvailable: 0,
           registeredDate: new Date(),
           money: 0,
-          gcl: 0
+          gcl: 0,
+          powerExperimentations: 30
         }
         return db.users.insert(user)
           .then(result => {


### PR DESCRIPTION
* Add `createUser()` CLI command
  * This makes it easier to create users for testing purposes or server initialization automation
* Add `registerSsoCpu` config param to set the default CPU for characters created via Steam/Github/Gitlab SSO options
  * This is the SSO-equivalent of the `registerCpu` config param used for password-based registration
* Update default params for all user creation methods:
  * Remove `power: 0` to remain consistent with official server behavior
  * Add `powerExperimentations: 30` to ensure all users get their power experimentation periods
